### PR TITLE
Convert all label inputs to string

### DIFF
--- a/reactive-governance/README.md
+++ b/reactive-governance/README.md
@@ -281,7 +281,7 @@ export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
     *   variables.tf
     *   terraform.tfvars.example
 
-2.  Open [terraform.tfvars](terraform/modules/cas-reactive/terraform.tfvars) file in your
+2.  Open [terraform.tfvars](sample-deployment/terraform.tfvars.example) file in your
     favourite editor and change values for the variables.
 
     ```sh

--- a/reactive-governance/label-automation/project_label_automation/src/automate_project_label.py
+++ b/reactive-governance/label-automation/project_label_automation/src/automate_project_label.py
@@ -106,6 +106,7 @@ def read_csv(csv_uri):
 
   # Access csv from gcs directly using url
   df = pd.read_csv(csv_uri)
+  df = df.astype(str)  # Convert DataFrame to string
   # print csv file content as table on console
   print("\n=== Print CSV Snippet (This may not display full csv) ===")
   print("=========================================================")


### PR DESCRIPTION
- Update link for terraform.tfvars to the new structure in the README.md
- fixing the issue when handling numbers converting all inputs to string before.

```
Traceback (most recent call last):
  File "/home/sgobe/labels/main.py", line 277, in <module>
    clear_and_apply_project_labels()
  File "/home/sgobe/labels/main.py", line 46, in clear_and_apply_project_labels
    df = read_csv(csv_uri)
         ^^^^^^^^^^^^^^^^^
  File "/home/sgobe/labels/main.py", line 114, in read_csv
    csv_error_count = parse_csv(df)
                      ^^^^^^^^^^^^^
  File "/home/sgobe/labels/main.py", line 262, in parse_csv
    if not pd.isnull(row[column]) and not re.match(value_pattern, row[column]):
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 167, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'int'
```